### PR TITLE
Refactor tenant-aware authentication

### DIFF
--- a/Manimp.Api/Program.cs
+++ b/Manimp.Api/Program.cs
@@ -1,4 +1,7 @@
+using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using Manimp.Auth.Models;
+using Manimp.Data.Contexts;
 using Manimp.Directory.Data;
 using Manimp.Shared.Interfaces;
 using Manimp.Services.Implementation;
@@ -13,6 +16,12 @@ builder.Services.AddSwaggerGen();
 // Add DbContext for Directory
 builder.Services.AddDbContext<DirectoryDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("Directory")));
+
+builder.Services.AddDbContextFactory<AppDbContext>();
+builder.Services.AddHttpContextAccessor();
+builder.Services.AddIdentityCore<ApplicationUser>()
+    .AddSignInManager();
+builder.Services.AddAuthentication();
 
 // Register services
 builder.Services.AddScoped<ITenantService, TenantService>();

--- a/Manimp.Web/Program.cs
+++ b/Manimp.Web/Program.cs
@@ -1,6 +1,9 @@
+using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using MudBlazor.Services;
 using Serilog;
+using Manimp.Auth.Models;
+using Manimp.Data.Contexts;
 using Manimp.Web.Components;
 using Manimp.Directory.Data;
 using Manimp.Shared.Interfaces;
@@ -25,6 +28,12 @@ builder.Services.AddMudServices();
 // Add DbContext for Directory
 builder.Services.AddDbContext<DirectoryDbContext>(options =>
     options.UseSqlServer(builder.Configuration.GetConnectionString("Directory")));
+
+builder.Services.AddDbContextFactory<AppDbContext>();
+builder.Services.AddHttpContextAccessor();
+builder.Services.AddIdentityCore<ApplicationUser>()
+    .AddSignInManager();
+builder.Services.AddAuthentication();
 
 // Register services
 builder.Services.AddScoped<ITenantService, TenantService>();


### PR DESCRIPTION
## Summary
- resolve tenant-specific `UserManager` and `SignInManager` using scoped services
- use `SignInManager.CheckPasswordSignInAsync` instead of manual `PasswordHasher`
- register identity and authentication services for tenant-aware operations

## Testing
- `dotnet build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_68c167cdc500832e8c2e412e9dea7d48